### PR TITLE
Spelling and grammar nits

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -190,7 +190,7 @@ WebTransport sessions.  On the wire, session IDs are encoded using the QUIC
 variable length integer scheme described in {{!RFC9000}}.
 
 If at any point a session ID is received that cannot a valid ID for a
-client-initiated bidirectional stream, the recepient MUST close the connection
+client-initiated bidirectional stream, the recipient MUST close the connection
 with an H3_ID_ERROR error code.
 
 ## Unidirectional streams
@@ -238,7 +238,7 @@ SHALL last until the end of the stream.
 HTTP/3 does not by itself define any semantics for server-initiated
 bidirectional streams.  If WebTransport setting is negotiated by both
 endpoints, the syntax of the server-initiated bidirectional streams SHALL be
-the same as the syntax of client-initated bidirectional streams, that is, a
+the same as the syntax of client-initiated bidirectional streams, that is, a
 sequence of HTTP/3 frames.  The only frame defined by this document for use
 within server-initiated bidirectional streams is WEBTRANSPORT_STREAM.
 
@@ -365,7 +365,7 @@ Application Error Code:
 Application Error Message:
 
 : A UTF-8 encoded error message string provided by the application closing the
-  connection.  The message takes up the remainer of the capsule, and its
+  connection.  The message takes up the remainder of the capsule, and its
   length MUST NOT exceed 1024 bytes.
 
 A CLOSE_WEBTRANSPORT_SESSION capsule MUST be followed by a FIN on the sender

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -88,7 +88,7 @@ both support WebTransport over HTTP/3.
 
 WebTransport sessions are initiated inside a given HTTP/3 connection by the
 client, who sends an extended CONNECT request {{!RFC8441}}.  If the server
-accepts the request, an WebTransport session is established.  The resulting
+accepts the request, a WebTransport session is established.  The resulting
 stream will be further referred to as a *CONNECT stream*, and its stream ID is
 used to uniquely identify a given WebTransport session within the connection.
 The ID of the CONNECT stream that established a given WebTransport session will
@@ -106,7 +106,7 @@ following mechanisms:
 * A datagram can be sent using HTTP Datagrams
   {{!HTTP-DATAGRAM=I-D.ietf-masque-h3-datagram}}.
 
-An WebTransport session is terminated when the CONNECT stream that created it
+A WebTransport session is terminated when the CONNECT stream that created it
 is closed.
 
 # Session Establishment


### PR DESCRIPTION
- s/an WebTransport/a WebTransport
- spellings
