### PR TITLE
Document how to close both the session and the underlying connection

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -420,7 +420,7 @@ CLOSE_WEBTRANSPORT_SESSION capsule that has an error code of 0 and an empty
 error string.
 
 In some scenarios, an endpoint might want to send a CLOSE_WEBTRANSPORT_SESSION
-with detailed close information, and then immediately close the underlying QUIC
+with detailed close information and then immediately close the underlying QUIC
 connection.  If the endpoint were to do both of those simultaneously, the peer
 could potentially receive the CONNECTION_CLOSE before receiving the
 CLOSE_WEBTRANSPORT_SESSION, thus never receiving the application error data

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -426,7 +426,7 @@ could potentially receive the CONNECTION_CLOSE before receiving the
 CLOSE_WEBTRANSPORT_SESSION, thus never receiving the application error data
 contained in the latter.  To avoid this, the endpoint SHOULD wait until either
 all of the data on the CONNECT stream is acknowledged, or three times the PTO
-interval ({{!RFC9002}}, Section 6.2) elapses, before sending the
+interval ({{!RFC9002, Section 6.2}}) elapses, before sending the
 CONNECTION_CLOSE.
 
 # Negotiating the Draft Version

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -424,10 +424,11 @@ with detailed close information and then immediately close the underlying QUIC
 connection.  If the endpoint were to do both of those simultaneously, the peer
 could potentially receive the CONNECTION_CLOSE before receiving the
 CLOSE_WEBTRANSPORT_SESSION, thus never receiving the application error data
-contained in the latter.  To avoid this, the endpoint SHOULD wait until either
-all of the data on the CONNECT stream is acknowledged, or three times the PTO
-interval ({{!RFC9002, Section 6.2}}) elapses, before sending the
-CONNECTION_CLOSE.
+contained in the latter.  To avoid this, the endpoint SHOULD wait until all of
+the data on the CONNECT stream is acknowledged before sending the
+CONNECTION_CLOSE; this gives CLOSE_WEBTRANSPORT_SESSION properties similar to
+that of the QUIC CONNECTION_CLOSE mechanism as a best-effort mechanism of
+delivering application close metadata.
 
 # Negotiating the Draft Version
 

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -419,6 +419,16 @@ capsule SHALL be semantically equivalent to terminating it with a
 CLOSE_WEBTRANSPORT_SESSION capsule that has an error code of 0 and an empty
 error string.
 
+In some scenarios, an endpoint might want to send a CLOSE_WEBTRANSPORT_SESSION
+with detailed close information, and then immediately close the underlying QUIC
+connection.  If the endpoint were to do both of those simultaneously, the peer
+could potentially receive the CONNECTION_CLOSE before receiving the
+CLOSE_WEBTRANSPORT_SESSION, thus never receiving the application error data
+contained in the latter.  To avoid this, the endpoint SHOULD wait until either
+all of the data on the CONNECT stream is acknowledged, or three times the PTO
+interval ({{!RFC9002}}, Section 6.2) elapses, before sending the
+CONNECTION_CLOSE.
+
 # Negotiating the Draft Version
 
 \[\[RFC editor: please remove this section before publication.]]


### PR DESCRIPTION
This is mostly based on what Chrome currently does in production.

Fixes #89.