### PR TITLE
Clarify Frame Type Registration section

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -547,8 +547,8 @@ Specification:
 The following entry is added to the "HTTP/3 Frame Type" registry established by
 [HTTP3]:
 
-The `WEBTRANSPORT_STREAM` frame allows HTTP/3 client-initiated bidirectional
-streams to be used by WebTransport:
+The `WEBTRANSPORT_STREAM` frame allows HTTP/3 client-initiated and
+server-initiated bidirectional streams to be used by WebTransport:
 
 Code:
 


### PR DESCRIPTION
This updates the IANA considerations section for Frame Type to match https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3-04#section-4.2, by including "server-initiated" in the type of bidirectional streams allowed by the `WEBTRANSPORT_STREAM` frame.