### PR TITLE
Clarify status code for Origin verification

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -157,7 +157,7 @@ Upon receiving an extended CONNECT request with a `:protocol` field set to
 `webtransport`, the HTTP/3 server can check if it has a WebTransport
 server associated with the specified `:authority` and `:path` values.  If it
 does not, it SHOULD reply with status code 404 ({{Section 15.5.5 of !HTTP=RFC9110}}).
-When the request provides `Origin` header, the WebTransport server MUST verify
+When the request contains the `Origin` header, the WebTransport server MUST verify
 the `Origin` header to ensure that the specified origin is allowed to access
 the server in question. If the verification fails, the WebTransport server
 SHOULD reply with status code 403 ({{Section 15.5.4 of HTTP}}).  If all checks pass, the

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -156,13 +156,13 @@ request; otherwise, the header is OPTIONAL.
 Upon receiving an extended CONNECT request with a `:protocol` field set to
 `webtransport`, the HTTP/3 server can check if it has a WebTransport
 server associated with the specified `:authority` and `:path` values.  If it
-does not, it SHOULD reply with status code 404 (Section 15.5.5, [HTTP]).
+does not, it SHOULD reply with status code 404 ({{Section 15.5.5 of !HTTP=RFC9110}}).
 When the request provides `Origin` header, the WebTransport server MUST verify
 the `Origin` header to ensure that the specified origin is allowed to access
 the server in question. If the verification fails, the WebTransport server
-SHOULD reply with status code 403 (Section 15.5.4).  If all checks pass, the
+SHOULD reply with status code 403 ({{Section 15.5.4 of HTTP}}).  If all checks pass, the
 WebTransport server MAY accept the session by replying with a 2xx series status
-code, as defined in Section 15.3 of {{!HTTP=RFC9110}}.
+code, as defined in {{Section 15.3 of HTTP}}.
 
 From the client's perspective, a WebTransport session is established when the
 client receives a 2xx response.  From the server's perspective, a session is

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -156,11 +156,13 @@ request; otherwise, the header is OPTIONAL.
 Upon receiving an extended CONNECT request with a `:protocol` field set to
 `webtransport`, the HTTP/3 server can check if it has a WebTransport
 server associated with the specified `:authority` and `:path` values.  If it
-does not, it SHOULD reply with status code 404 (Section 15.5.4, [HTTP]).
-If it does, it MAY accept the session by replying with a 2xx series status
-code, as defined in Section 15.3 of {{!HTTP=RFC9110}}.  The WebTransport
-server MUST verify the `Origin` header to ensure that the specified origin is
-allowed to access the server in question.
+does not, it SHOULD reply with status code 404 (Section 15.5.5, [HTTP]).
+When the request provides `Origin` header, the WebTransport server MUST verify
+the `Origin` header to ensure that the specified origin is allowed to access
+the server in question. If the verification fails, the WebTransport server
+SHOULD reply with status code 403 (Section 15.5.4).  If all checks pass, the
+WebTransport server MAY accept the session by replying with a 2xx series status
+code, as defined in Section 15.3 of {{!HTTP=RFC9110}}.
 
 From the client's perspective, a WebTransport session is established when the
 client receives a 2xx response.  From the server's perspective, a session is


### PR DESCRIPTION
In https://github.com/web-platform-tests/wpt/pull/38782, it was suggested that 403 status code should be used when Origin verification fails.