### PR TITLE
Expand on HTTP/3 extension aspects

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -266,8 +266,6 @@ special signal value, encoded as a variable-length integer, as the first bytes
 of the stream in order to indicate how the remaining bytes on the stream are
 used.
 
-TODO: consider extracting special signal values into a separate draft;
-
 The signal value, 0x41, is used by clients and servers to open a bidirectional
 WebTransport stream.  Following this is the associated session ID, encoded as a
 variable-length integer; the rest of the stream is the application payload of

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -254,14 +254,14 @@ streams, which are a sequence of HTTP/3 frames with a variety of rules; see
 {{Sections 4.1 and 6.1 of HTTP3}}.
 
 WebTransport extends HTTP/3 to allow clients to declare and use alternative
-request stream rules.  Once WebTransport has been established
-({{establishing}}), a client can send a special signal value, encoded as a
-variable-length integer, as the first bytes of the stream in order to indicate
+request stream rules.  Once a client receives settings indicating WebTransport
+support ({{establishing}}), it can send a special signal value, encoded as
+a variable-length integer, as the first bytes of the stream in order to indicate
 how the remaining bytes on the stream are used.
 
 WebTransport extends HTTP/3 by defining rules for all server-initiated
-bidirectional streams.  Once WebTransport has been established
-({{establishing}}), a server can open a bidirectional stream and SHALL send a
+bidirectional streams.  Once a server receives settings indicating WebTransport
+support ({{establishing}}), it can open a bidirectional stream and SHALL send a
 special signal value, encoded as a variable-length integer, as the first bytes
 of the stream in order to indicate how the remaining bytes on the stream are
 used.


### PR DESCRIPTION
By switching from Frames to special signal values at byte position 0,
we are really extending HTTP/3 rules. So this is an attempt to paint
that out more cleanly and tidy up some loose ends or stale text in the
draft.

The outcome is that we make it clear that WebTransport streams never use
frames. Instead, they are always a sequence of some preamble at the
start of a stream, followed by a session ID, followed by user-specified
stream data. This makes it more obvious that endpoints should never send
0x41 such that the peer could interpret it as being a frame on any
frame-bearing stream (like the control stream). If you understand
WebTransport but didn't enable it, then receiving 0x41 is also bad, so
blow up.