### PR TITLE
Relationship between WebTransport, HTTP/3 and QUIC

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -93,7 +93,7 @@ static decompression is mandatory to support.
 
 WebTransport over HTTP/3 makes it possible for an application to directly access
 QUIC transport via an HTTP/3 connection. HTTP/3 is the application mapping for
-QUIC, defined in RFC 9113, which describes how streams are used to carry control
+QUIC, defined in {{!RFC9113}}, which describes how streams are used to carry control
 data or HTTP request and response message sequences in the form of frames, as
 well as describing details of stream and connection lifecycle management.
 
@@ -112,7 +112,7 @@ This is important or the Web security model where same-origin and cross-origin r
 access is very important. Post-handshake, QUIC streams use header bytes
 for accounting purposes, but after that an application can use QUIC
 streams however it would like. This is similar to WebSockets over
-HTTP/1.1, where access is enabled to the underlying bytestream after
+HTTP/1.1 {{RFC6455}}, where access is enabled to the underlying bytestream after
 both sides have agreed the handshake. As a result, WebTransport
 layering appears as follows:
 

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -112,12 +112,12 @@ This is important or the Web security model where same-origin and cross-origin r
 access is very important. Post-handshake, QUIC streams use header bytes
 for accounting purposes, but after that an application can use QUIC
 streams however it would like. This is similar to WebSockets over
-HTTP/1.1 {{RFC6455}}, where access is enabled to the underlying bytestream after
+HTTP/1.1, where access is enabled to the underlying bytestream after
 both sides have agreed the handshake. As a result, WebTransport
 layering appears as follows:
 
 ~~~~~~~~~~ drawing
-|       WebTrasnport       |
+|       WebTransport       |
 |  Punch  | HTTP Semantics |
 | Through |   HTTP/3       |
 |          QUIC            |

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -80,12 +80,13 @@ can be accessed via an HTTP/3 server.
 
 ## WebTransport, QUIC and HTTP/3
 
-QUIC v1 transport [RFC9000] provides security, stream multiplexing,
-reliable and ordered streams, stream HoL blocking avoidance, flow
-control, and congestion control. The transport layer provides these
-services to applications but does not constrain how streams are used.
+"QUIC: A UDP-Based Multiplexed and Secure Transport" {{!RFC9000}}
+defines QUIC security, stream multiplexing, reliable and ordered streams,
+stream HoL blocking avoidance, flow control, and congestion control.
+The transport layer provides these services to applications but does
+not constrain how streams are used.
 
-HTTP is an application-layer protocol, defined by "HTTP Semantics" [RFC9110].
+HTTP is an application-layer protocol, defined by "HTTP Semantics" {{!RFC9110}}.
 HTTP/3 has specific features that are not part of the HTTP semantics: QPACK
 header compression (static and dynamic) and Server Push. Of these, only
 static decompression is mandatory to support.
@@ -113,12 +114,15 @@ for accounting purposes, but after that an application can use QUIC
 streams however it would like. This is similar to WebSockets over
 HTTP/1.1, where access is enabled to the underlying bytestream after
 both sides have agreed the handshake. As a result, WebTransport
-layering appears as follows: 
+layering appears as follows:
 
-|       WebTranport        |
+~~~~~~~~~~ drawing
+|       WebTrasnport       |
 |  Punch  | HTTP Semantics |
 | Through |   HTTP/3       |
 |          QUIC            |
+~~~~~~~~~~
+{: #fig-webtransport-layers title="WebTransport Layering"}
 
 ## Protocol Overview
 


### PR DESCRIPTION
Fix for #111

Discussion at Nov 28, 2023 editor's meeting: Include a section describing the layering of WebTransport, HTTP/3 and QUIC, based on: https://mailarchive.ietf.org/arch/msg/moq/yOnZu3d5mDZGcV1mBODJ2-MTeko/

(Thanks to Lucas)