### PR TITLE
Adjust SETTINGS, buffering requirements, waiting for session establishment

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -152,7 +152,7 @@ by {{!RFC9220}}.  A server supporting WebTransport over HTTP/3 MUST send both
 the SETTINGS_WEBTRANSPORT_MAX_SESSIONS setting with a value greater than "0"
 and the SETTINGS_ENABLE_CONNECT_PROTOCOL setting with a value of "1".  To use
 WebTransport over HTTP/3, clients MUST send the
-SETTINGS_ENABLE_CONNECT_PROTOCOL setting with a value of "1". 
+SETTINGS_ENABLE_CONNECT_PROTOCOL setting with a value of "1".
 
 ## Creating a New Session
 


### PR DESCRIPTION
Adjust SETTINGS, buffering requirements, waiting for session establishment

As discussed: 
- Client MUST wait for server settings
- Endpoints MUST send SETTINGS_H3_DATAGRAM (however servers that want to validate this MUST need to take into account the fact that the request might arrive before the client's SETTINGS)
- Client no longer sends the WEBTRANSPORT_MAX_SESSIONS setting
- Add a "Considerations for future versions of WebTransport" section that explain that if a future version of WebTransport changes the syntax of the request, it'll need to change the Upgrade Token. Similarly, changes to stream formats will require changes to the Unidirectional Stream Type and Bidirectional Stream Signal Value.

Fixes #135, #140, #141, and #143