### PR TITLE
Clarify that the CONNECT stream isn't included in the per-session stream flow control limits

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -586,7 +586,12 @@ The WT_MAX_STREAMS capsule ({{WT_MAX_STREAMS}}) establishes a limit on the
 number of streams within a WebTransport session.  Like the QUIC MAX_STREAMS
 frame ({{Section 19.11 of !RFC9000}}), this capsule has two types that provide
 separate limits for unidirectional and bidirectional streams that are initiated
-by a peer.
+by a peer. 
+
+Note that the CONNECT stream for the session is not included in either the
+bidirectional or the unidirectional stream limits; the number of CONNECT
+streams a client can open is limited by the SETTINGS_WEBTRANSPORT_MAX_SESSIONS
+setting and QUIC flow control's stream limits.
 
 The session-level stream limit applies in addition to the QUIC MAX_STREAMS
 frame, which provides a connection-level stream limit.  New streams can only be

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -586,7 +586,7 @@ The WT_MAX_STREAMS capsule ({{WT_MAX_STREAMS}}) establishes a limit on the
 number of streams within a WebTransport session.  Like the QUIC MAX_STREAMS
 frame ({{Section 19.11 of !RFC9000}}), this capsule has two types that provide
 separate limits for unidirectional and bidirectional streams that are initiated
-by a peer. 
+by a peer.
 
 Note that the CONNECT stream for the session is not included in either the
 bidirectional or the unidirectional stream limits; the number of CONNECT


### PR DESCRIPTION
Clarify that the CONNECT stream isn't included in the per-session stream flow control limits.

Fixes #176