### PR TITLE
Replace HTTP_REQUEST_REJECTED with H3_REQUEST_REJECTED

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -577,8 +577,8 @@ than indicated in the server SETTINGS parameter.  The server MUST NOT close
 the connection if the client opens sessions exceeding this limit, as the client
 and the server do not have a consistent view of how many sessions are open due
 to the asynchronous nature of the protocol; instead, it MUST reset all of the
-CONNECT streams it is not willing to process with the `HTTP_REQUEST_REJECTED`
-status defined in {{HTTP3}}.
+CONNECT streams it is not willing to process with the `H3_REQUEST_REJECTED`
+status defined in {{Section 8.1 of HTTP3}}.
 
 ## Limiting the Number of Streams Within a Session {#flow-control-limit-streams}
 


### PR DESCRIPTION
Updates `HTTP_REQUEST_REJECTED` to `H3_REQUEST_REJECTED` and adds the correct reference for the HTTP/3 error codes.