### PR TITLE
Clarify GOAWAY allows only new WebTransport streams

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -517,9 +517,9 @@ WT_DRAIN_SESSION Capsule {
 ~~~
 
 After sending or receiving either a WT_DRAIN_SESSION capsule or a HTTP/3 GOAWAY
-frame, an endpoint MAY continue using the session and MAY open new streams. The
-signal is intended for the application using WebTransport, which is expected to
-attempt to gracefully terminate the session as soon as possible.
+frame, an endpoint MAY continue using the session and MAY open new WebTransport
+streams. The signal is intended for the application using WebTransport, which is
+expected to attempt to gracefully terminate the session as soon as possible.
 
 ## Use of Keying Material Exporters
 


### PR DESCRIPTION
This does not modify HTTP/3 rules indicating that HTTP clients cannot send new requests with a stream ID greater or equal to the one in GOAWAY.

Fixes: #190