### PR TITLE
Align on terminology for application vs. endpoint

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -77,10 +77,10 @@ that this document distinguishes between a WebTransport server and an HTTP/3
 server.  An HTTP/3 server is the server that terminates HTTP/3 connections; a
 WebTransport server is an application that accepts WebTransport sessions, which
 can be accessed via an HTTP/3 server.  An application client is user or
-developer-provided code, often untrusted, that utilizes the interface offered by
-the WebTransport client to communicate with an application server. The 
-application server uses the interface offered by the WebTransport server 
-to accept incoming WebTransport sessions.
+developer-provided code, often untrusted, that utilizes the interface offered
+by the WebTransport client to communicate with an application server. The
+application server uses the interface offered by the WebTransport server to
+accept incoming WebTransport sessions.
 
 # Overview
 
@@ -102,8 +102,8 @@ addition to HTTP Semantics: QPACK header compression {{?RFC9208}} and Server
 Push {{Section 4.6 of RFC9114}}.
 
 WebTransport session establishment involves interacting at the HTTP layer with a
-resource.  For Web user agents, or "WebTransport clients", this interaction is
-important for security reasons, especially to ensure that the resource is
+resource.  For Web user agents and other WebTransport clients, this interaction
+is important for security reasons, especially to ensure that the resource is
 willing to use WebTransport.
 
 Although WebTransport requires HTTP for its handshake, when HTTP/3 is in use,
@@ -244,8 +244,8 @@ in {{Section 3 of RESET-STREAM-AT}}.
 As WebTransport sessions are established over HTTP/3, they are identified using
 the `https` URI scheme ({{Section 4.2.2 of HTTP}}).
 
-In order to create a new WebTransport session, a client sends an HTTP extended
-CONNECT request.  In this request:
+In order to create a new WebTransport session, a WebTransport client sends an
+HTTP extended CONNECT request.  In this request:
 
 * The `:protocol` pseudo-header field({{!RFC8441}}) MUST be set to
   `webtransport`.

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -77,10 +77,10 @@ that this document distinguishes between a WebTransport server and an HTTP/3
 server.  An HTTP/3 server is the server that terminates HTTP/3 connections; a
 WebTransport server is an application that accepts WebTransport sessions, which
 can be accessed via an HTTP/3 server.  An application client is user or
-developer-provided code, often untrusted, that uses the interface offered by
-the WebTransport client to communicate with an application server, which in
-turn uses the interface offered by the WebTransport server to accept incoming
-WebTransport sessions.
+developer-provided code, often untrusted, that utilizes the interface offered by
+the WebTransport client to communicate with an application server. The 
+application server uses the interface offered by the WebTransport server 
+to accept incoming WebTransport sessions.
 
 # Overview
 
@@ -108,7 +108,7 @@ willing to use WebTransport.
 
 Although WebTransport requires HTTP for its handshake, when HTTP/3 is in use,
 HTTP is not used for anything else related to an established session.  Instead,
-QUIC streams begin with a header sequence of bytes that links them to the
+QUIC streams begin with a sequence of header bytes that links them to the
 established session.  The remainder of the stream is the body, which carries
 the payload supplied by the application using WebTransport.  This process is
 similar to WebSockets over HTTP/1.1 {{?ORIGIN=RFC6455}}, where access to the
@@ -250,8 +250,8 @@ CONNECT request.  In this request:
 * The `:protocol` pseudo-header field({{!RFC8441}}) MUST be set to
   `webtransport`.
 * The `:scheme` field MUST be `https`.
-* Both the `:authority` and the `:path` value MUST be set; these fields indicate
-  the desired WebTransport server.
+* Both the `:authority` and the `:path` value MUST be set; these fields identify
+  the desired WebTransport server resource.
 * If the WebTransport session is coming from a browser client, an `Origin`
   header {{!RFC6454}} MUST be provided within the request.  Otherwise, the
   header is OPTIONAL.
@@ -446,7 +446,7 @@ implementations MUST remap those error codes into the error range reserved for
 WT_APPLICATION_ERROR, where 0x00000000 corresponds to 0x52e4a40fa8db, and
 0xffffffff corresponds to 0x52e5ac983162.  Note that there are codepoints
 inside that range of form "0x1f * N + 0x21" that are reserved by {{Section 8.1
-of HTTP3}}; those have to be skipped when mapping the error codes (i.e. the two
+of HTTP3}}; those have to be skipped when mapping the error codes (i.e., the two
 HTTP/3 error codepoints adjacent to a reserved codepoint would map to two
 adjacent WebTransport application error codepoints). An example pseudocode can
 be seen in {{fig-remap-errors}}.

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -375,7 +375,7 @@ with an H3_ID_ERROR error code.
 ## Unidirectional streams {#unidirectional-streams}
 
 WebTransport endpoints can initiate unidirectional streams.  The HTTP/3
-unidirectional stream type SHALL be `0x54`.  The body of the stream SHALL be the
+unidirectional stream type SHALL be 0x54.  The body of the stream SHALL be the
 stream type, followed by the session ID, encoded as a variable-length integer,
 followed by the user-specified stream data ({{fig-unidi}}).
 
@@ -408,7 +408,7 @@ bidirectional stream for use with that session and MUST send a special signal
 value, encoded as a variable-length integer, as the first bytes of the stream
 in order to indicate how the remaining bytes on the stream are used.
 
-Clients and servers use the signal value `0x41` to open a bidirectional
+Clients and servers use the signal value 0x41 to open a bidirectional
 WebTransport stream.  Following this is the associated session ID, encoded as a
 variable-length integer; the rest of the stream is the application payload of
 the WebTransport stream ({{fig-bidi-client}}).
@@ -422,7 +422,7 @@ Bidirectional Stream {
 ~~~~~~~~~~
 {: #fig-bidi-client title="Bidirectional WebTransport stream format"}
 
-This document reserves the special signal value `0x41` as a WT_STREAM frame
+This document reserves the special signal value 0x41 as a WT_STREAM frame
 type.  While it is registered as an HTTP/3 frame type to avoid collisions,
 WT_STREAM lacks length and is not a proper HTTP/3 frame; it is an extension of
 HTTP/3 frame syntax that MUST be supported by any peer negotiating


### PR DESCRIPTION
Align on terminology for application vs. endpoint

Also took the opportunity to do an editorial pass.

Generally, this is fairly editorial, although there are a few changes to normative text -- they're not intended to change the meaning, but please do double check.

Fixes #191