### PR TITLE
clarify that WT_MAX_DATA only requires special QUIC API for reset streams

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -680,8 +680,7 @@ For streams that were reset, implementing WT_MAX_DATA requires that the QUIC
 stack provide the WebTransport implementation with information about the final
 size of streams; see {{Section 4.5 of !RFC9000}}.  This guarantees that both
 endpoints agree on how much WebTransport session flow control credit was
-consumed by the sender on that stream, after subtracting the number of bytes
-used by the stream header.
+consumed by the sender on that stream.
 
 The WT_DATA_BLOCKED capsule ({{WT_DATA_BLOCKED}}) can be sent to indicate that
 an endpoint was unable to send data due to a limit set by the WT_MAX_DATA


### PR DESCRIPTION
At least that's my understanding of how one would implement this. For streams that are closed without an error, all byte counting can happen at the WebTransport layer, and no additional QUIC API is needed.