### PR TITLE
Separate out settings prose and registration

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -744,16 +744,50 @@ capsule as a session error.
 
 ## Flow Control SETTINGS
 
-*[SETTINGS_WT_INITIAL_MAX_STREAMS_UNI]: #
-*[SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI]: #
-*[SETTINGS_WT_INITIAL_MAX_DATA]: #
-
 Initial flow control limits can be exchanged via HTTP/3 SETTINGS
 ({{http3-settings}}) by providing non-zero values for
 
 * WT_MAX_STREAMS via SETTINGS_WT_INITIAL_MAX_STREAMS_UNI and
   SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI
 * WT_MAX_DATA via SETTINGS_WT_INITIAL_MAX_DATA
+
+### SETTINGS_WT_INITIAL_MAX_STREAMS_UNI
+
+The SETTINGS_WT_INITIAL_MAX_STREAMS_UNI setting indicates the initial value for
+the unidirectional max stream limit, otherwise communicated by the
+WT_MAX_STREAMS capsule (see {{WT_MAX_STREAMS}}).  The default value for the
+SETTINGS_WT_INITIAL_MAX_STREAMS_UNI setting is "0", indicating that the
+endpoint needs to send WT_MAX_STREAMS capsules on each individual WebTransport
+session before its peer is allowed to create any unidirectional streams within
+that session.
+
+Note that this limit applies to all WebTransport sessions that use the HTTP/3
+connection on which this SETTING is sent.
+
+### SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI
+
+The SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI setting indicates the initial value for
+the bidirectional max stream limit, otherwise communicated by the
+WT_MAX_STREAMS capsule (see {{WT_MAX_STREAMS}}).  The default value for the
+SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI setting is "0", indicating that the
+endpoint needs to send WT_MAX_STREAMS capsules on each individual WebTransport
+session before its peer is allowed to create any bidirectional streams within
+that session.
+
+Note that this limit applies to all WebTransport sessions that use the HTTP/3
+connection on which this SETTING is sent.
+
+### SETTINGS_WT_INITIAL_MAX_DATA
+
+The SETTINGS_WT_INITIAL_MAX_DATA setting indicates the initial value for the
+session data limit, otherwise communicated by the WT_MAX_DATA capsule (see
+{{WT_MAX_DATA}}).  The default value for the SETTINGS_WT_INITIAL_MAX_DATA
+setting is "0", indicating that the endpoint needs to send a WT_MAX_DATA
+capsule within each session before its peer is allowed to send any stream data
+within that session.
+
+Note that this limit applies to all WebTransport sessions that use the HTTP/3
+connection on which this SETTING is sent.
 
 ## Flow Control Capsules
 
@@ -1112,15 +1146,9 @@ Reference:
 The following entry is added to the "HTTP/3 Settings" registry established by
 [HTTP3]:
 
-The `SETTINGS_WT_MAX_SESSIONS` setting indicates that the specified HTTP/3
-endpoint is WebTransport-capable and the number of concurrent sessions it is
-willing to receive.  The default value for the SETTINGS_WT_MAX_SESSIONS setting
-is "0", meaning that the endpoint is not willing to receive any WebTransport
-sessions.
-
 Setting Name:
 
-: WT_MAX_SESSIONS
+: SETTINGS_WT_MAX_SESSIONS
 
 Value:
 
@@ -1134,18 +1162,11 @@ Specification:
 
 : This document
 
-{: anchor="SETTINGS_WT_INITIAL_MAX_STREAMS_UNI"}
+Change Controller:
+: IETF
 
-The SETTINGS_WT_INITIAL_MAX_STREAMS_UNI setting indicates the initial value for
-the unidirectional max stream limit, otherwise communicated by the
-WT_MAX_STREAMS capsule (see {{WT_MAX_STREAMS}}).  The default value for the
-SETTINGS_WT_INITIAL_MAX_STREAMS_UNI setting is "0", indicating that the
-endpoint needs to send WT_MAX_STREAMS capsules on each individual WebTransport
-session before its peer is allowed to create any unidirectional streams within
-that session.
-
-Note that this limit applies to all WebTransport sessions that use the HTTP/3
-connection on which this SETTING is sent.
+Contact:
+: WebTransport Working Group <webtransport@ietf.org>
 
 Setting Name:
 
@@ -1163,18 +1184,11 @@ Specification:
 
 : This document
 
-{: anchor="SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI"}
+Change Controller:
+: IETF
 
-The SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI setting indicates the initial value for
-the bidirectional max stream limit, otherwise communicated by the
-WT_MAX_STREAMS capsule (see {{WT_MAX_STREAMS}}).  The default value for the
-SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI setting is "0", indicating that the
-endpoint needs to send WT_MAX_STREAMS capsules on each individual WebTransport
-session before its peer is allowed to create any bidirectional streams within
-that session.
-
-Note that this limit applies to all WebTransport sessions that use the HTTP/3
-connection on which this SETTING is sent.
+Contact:
+: WebTransport Working Group <webtransport@ietf.org>
 
 Setting Name:
 
@@ -1192,17 +1206,11 @@ Specification:
 
 : This document
 
-{: anchor="SETTINGS_WT_INITIAL_MAX_DATA"}
+Change Controller:
+: IETF
 
-The SETTINGS_WT_INITIAL_MAX_DATA setting indicates the initial value for the
-session data limit, otherwise communicated by the WT_MAX_DATA capsule (see
-{{WT_MAX_DATA}}).  The default value for the SETTINGS_WT_INITIAL_MAX_DATA
-setting is "0", indicating that the endpoint needs to send a WT_MAX_DATA
-capsule within each session before its peer is allowed to send any stream data
-within that session.
-
-Note that this limit applies to all WebTransport sessions that use the HTTP/3
-connection on which this SETTING is sent.
+Contact:
+: WebTransport Working Group <webtransport@ietf.org>
 
 Setting Name:
 
@@ -1219,6 +1227,12 @@ Default:
 Specification:
 
 : This document
+
+Change Controller:
+: IETF
+
+Contact:
+: WebTransport Working Group <webtransport@ietf.org>
 
 ## Frame Type Registration
 


### PR DESCRIPTION
SETTINGS_WT_MAX_SESSIONS already had prose in section 3.1 that was not consistently
duplicated in 9.2, so I just deleted it.

Prose about SETTINGS for flow control is moved to section 5.5 which was already
called "Flow Control SETTINGS".

The first version of this PR nukes some of the anchor magic because it seemed a bit pointless to me. But if people feel strongly then it can be added back.