### PR TITLE
Specify handling of CONNECT-stream capsule bytes before session accepted

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -337,6 +337,13 @@ The "webtransport-h3" HTTP Upgrade Token uses the Capsule Protocol as defined in
 {{Section 3.4 of HTTP-DATAGRAM}} is not required by WebTransport and can safely
 be ignored by WebTransport endpoints.
 
+To reduce latency at the start of a WebTransport session, a client MAY
+optimistically send capsules on the CONNECT stream before receiving the
+server's response.  A server MUST NOT process these bytes as capsules until
+it sends a 2xx response accepting the session.  Bytes received before the
+server sends the response are processed once the session is accepted or
+discarded if the session is rejected.
+
 ## Application Protocol Negotiation {#protocol-negotiation}
 
 WebTransport over HTTP/3 offers a protocol negotiation mechanism, similar to the


### PR DESCRIPTION
Add explicit text that a client MAY optimistically send capsules before the server's response, and that the server MUST NOT process these bytes as capsules until it sends a 2xx accepting the session.

Fixes #265 