### PR TITLE
WebTransport is enabled with a "1"

### DIFF
--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -221,7 +221,7 @@ This document defines a SETTINGS_WT_ENABLED setting that WebTransport servers
 use to indicate their support for WebTransport.  The default value for the
 SETTINGS_WT_ENABLED setting is "0", meaning that the server does not support
 WebTransport.  A value of "1" indicates support for the variant of WebTransport
-that is described in this document (that is, "webtransport-h3").  Clients MAY
+that is described in this document (that is, "webtransport-h3").  Clients MUST
 treat values greater than "1" as a connection error of type H3_SETTINGS_ERROR.
 Clients MUST NOT attempt to establish WebTransport sessions with the
 "webtransport-h3" token until they have received the setting indicating

--- a/draft-ietf-webtrans-http3.md
+++ b/draft-ietf-webtrans-http3.md
@@ -220,8 +220,12 @@ establishing sessions (see {{upgrade-token}}).
 This document defines a SETTINGS_WT_ENABLED setting that WebTransport servers
 use to indicate their support for WebTransport.  The default value for the
 SETTINGS_WT_ENABLED setting is "0", meaning that the server does not support
-WebTransport.  Clients MUST NOT attempt to establish WebTransport sessions until
-they have received the setting indicating WebTransport support from the server.
+WebTransport.  A value of "1" indicates support for the variant of WebTransport
+that is described in this document (that is, "webtransport-h3").  Clients MAY
+treat values greater than "1" as a connection error of type H3_SETTINGS_ERROR.
+Clients MUST NOT attempt to establish WebTransport sessions with the
+"webtransport-h3" token until they have received the setting indicating
+WebTransport support from the server.
 
 WebTransport over HTTP/3 uses extended CONNECT in HTTP/3 as described in
 {{!RFC9220}}, which defines the SETTINGS_ENABLE_CONNECT_PROTOCOL setting.
@@ -244,7 +248,7 @@ reset_stream_at transport parameter as described in
 
 In summary, servers supporting WebTransport over HTTP/3 send:
 
-- A SETTINGS_WT_ENABLED setting with a value greater than "0"
+- A SETTINGS_WT_ENABLED setting with a value of "1"
 - A SETTINGS_ENABLE_CONNECT_PROTOCOL setting with a value of "1"
 - A SETTINGS_H3_DATAGRAM setting with a value of 1
 - A max_datagram_frame_size transport parameter with a value greater than 0


### PR DESCRIPTION
Only.  Other values result in `H3_SETTINGS_ERROR`.

This is consistent with `SETTINGS_ENABLE_CONNECT_PROTOCOL`, where the only valid values are 0 or 1.

I've also added a mention of the setting have no effect when sent by a client.

Closes #275.